### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,18 +14,20 @@
   "bugs": {
     "url": "https://github.com/kmulvey/grunt-beaker/issues"
   },
-  "licenses": [{
-		"type": "Apache v2",
-		"url": "http://www.apache.org/licenses/"
-  }],
+  "licenses": [
+    {
+      "type": "Apache v2",
+      "url": "http://www.apache.org/licenses/"
+    }
+  ],
   "main": "Gruntfile.js",
   "devDependencies": {
-  "grunt": "",
-  "grunt-contrib-jshint": "",
-  "grunt-contrib-nodeunit": ""
+    "grunt": "",
+    "grunt-contrib-jshint": "",
+    "grunt-contrib-nodeunit": ""
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
